### PR TITLE
1 week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+application-secret.yml

--- a/records/1Week_KimHeeYeon.md
+++ b/records/1Week_KimHeeYeon.md
@@ -1,0 +1,137 @@
+## Title: [1Week] 김희연
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+
+**호감 상대 삭제**
+
+[x] 호감 상대 삭제 테스트 코드 작성
+
+[x] 삭제 시, 삭제 권한이 있는지 체크
+
+[x] 삭제 후, 다시 호감 목록 페이지로 이동
+
+<br>
+
+**구글 로그인**
+
+[x] 구글 로그인으로 가입한 회원인 providerTypeCode : GOOGLE
+
+[x] 로그인 후, username 출력
+
+<br>
+
+### 1주차 미션 요약
+
+---
+
+**호감 상대 삭제**
+- 삭제버튼을 누르면, 해당 항목은 삭제되어야 한다.
+- 삭제 후 다시 호감 목록 페이지로 돌아와야 한다. (rq.redirectWithMsg 함수 사용)
+
+**구글 로그인**
+- 구글 로그인으로 가입 및 로그인 처리(스프링 OAuth2 클라이언트로 구현)
+- 구글 로그인으로 가입한 회원의 providerTypeCode : GOOGLE
+
+<br>
+
+[접근 방법]
+- 삭제 권한 체크
+
+<첫번째 시도>
+
+현재 로그인한 회원의 정보가 있어야한다는 생각에 `Principal`을 사용하였다.
+
+`Principal.getName()`과 비교하기 위해서 `호감을 표시한 멤버의 username`이 필요했다.
+
+[`호감을 표시한 멤버의 username` 구하기]
+
+1. 호감을 받은 받은 사람 객체를 구하기
+2. 호감 받은 사람에 대해 호감을 표시한 사람의 인스타 아이디 구하기
+3. 인스타 아이디에 해당하는 멤버 객체 구하기
+
+`호감 표시를 한 멤버의 아이디`와 `현재 로그인한 회원의 username`이 같은지 확인
+
+```java
+@PreAuthorize("isAuthenticated()")
+@GetMapping("/delete/{id}")
+public String delete(Principal principal, @PathVariable("id") int id){
+    //호감을 받은 사람(LikeablePerson) - 호감을 표시한 사람(InstaMember) - 회원가입한 모든 회원(Member) 가 모두 연결되어 있다.
+    LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
+    Long InstaMemberId = likeablePerson.getFromInstaMember().getId(); //호감 받은 사람에 대해 호감 표시를 한 사람의 인스타 아이디 구하기
+    Member member = memberService.getMember(InstaMemberId).get(); //인스타 아이디에 해당하는 멤버 객체 구하기
+    if (!member.getUsername().equals(principal.getName())) { //호감 표시를 멤버의 아이디와 현재 로그인한 회원의 아이디와 같은지 확인하기
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
+    }
+    likeablePersonService.delete(likeablePerson);
+    return rq.redirectWithMsg("/likeablePerson/list", "삭제");
+}
+```
+<br>
+
+<두번째 시도>
+
+이미 만들어놓은 `Rq`를 사용하면 조금 더 편리해질 것 같았다.
+
+```java
+
+@GetMapping("/delete/{id}")
+public String delete(@PathVariable("id") int id){
+    //호감을 받은 사람(LikeablePerson) - 호감을 표시한 사람(InstaMember) - 회원가입한 모든 회원(Member) 가 모두 연결되어 있다.
+    LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
+    Long InstaMemberId = likeablePerson.getFromInstaMember().getId(); //호감 받은 사람에 대해 호감 표시를 한 사람의 인스타 아이디 구하기
+    Member member = memberService.getMember(InstaMemberId).get(); //인스타 아이디에 해당하는 멤버 객체 구하기
+    if (!member.getUsername().equals(rq.getMember().getUsername())) { //호감 표시를 멤버의 아이디와 현재 로그인한 회원의 아이디와 같은지 확인하기
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
+    }
+    likeablePersonService.delete(likeablePerson);
+    return rq.redirectWithMsg("/likeablePerson/list", "삭제");
+}
+```
+<br>
+
+<세번째 시도_최종코드>
+
+강사님의 힌트로, 삭제 권한을 확인하는 조건은 `멤버의 username`이 아닌 `인스타 아이디`라는 것을 알게되었다.
+
+- 호감을 표시한 사람이 삭제 권한이 있으므로 호감을 표시한 사람인지를 확인해야 한다.
+- 호감을 표시한 사람은 인스타 아이디로 확인가능하다.
+
+`호감을 표시한 멤버의 인스타 아이디` 와 `현재 로그인한 회원의 인스타 아이디` 가 같은지 확인
+
+```java
+@GetMapping("/delete/{id}")
+    public String delete(@PathVariable("id") int id){
+        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
+        if (likeablePerson.getFromInstaMember().getId() != rq.getMember().getInstaMember().getId()) { //"호감을 표시한 멤버의 인스타 아이디"와 "현재 로그인한 회원의 인스타 아이디"가 같은지 확인하기
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
+        }
+        likeablePersonService.delete(likeablePerson);
+        return rq.redirectWithMsg("/likeablePerson/list", "삭제");
+    }
+```
+
+첫번째 코드가 틀렸다고는 할 수 없지만, 삭제 조건에 대해 많이 돌아가서 구현했다면, 세번째 코드는 훨씬 간결해진 것을 볼 수 있다!
+
+<br>
+
+- 구글 계정 접속
+
+이전에 구현한 카카오 로그인과 관련된 소스 코드를 참고하였다.
+
+`CustomOAuth2UserService`, `SecurityConfig`, `MemberService-join()`, `MemberService-whenSocialLogin` 등이 관련되어 있었지만, 구글 로그인 또한 함께 써도 무방하였다.
+
+그래서 수정한 코드는 `application.yml` 코드 뿐이다.
+Google에 맞춰서 수정하기 위해서 구글 검색을 많이 하였고, 여러 블로그들을 참고하였다.
+
+또한, `client-id`와 `client-secret`을 구하기 위해 계정을 생성하였다.
+
+<br>
+
+**[특이사항]**
+- 삭제 버튼을 눌렀으나, 삭제가 되지 않았다.
+-> `@Transactional(readOnly = true)` 때문이었다. `@Transactional`을 붙여주어야 한다.
+
+
+- 구글 소셜 로그인과 관련한 블로그들은 많았지만, 이들을 조합해서 나에게 맞는 소스 코드로 적용하기까지 시간이 많이 소요되었다.

--- a/src/main/java/com/ll/gramgram/DataNotFoundException.java
+++ b/src/main/java/com/ll/gramgram/DataNotFoundException.java
@@ -1,0 +1,13 @@
+package com.ll.gramgram;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "entity not found")
+public class DataNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    public DataNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -25,7 +25,7 @@ public class NotProd {
             Member memberUser3 = memberService.join("user3", "1234").getData();
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
-            Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733221978").getData();
+            Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2737847912").getData();
             Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__100605279337988090302").getData();
 
 

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -26,6 +26,8 @@ public class NotProd {
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733221978").getData();
+            Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__100605279337988090302").getData();
+
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberService memberService;
 
-    // 카카오톡 로그인이 성공할 때 마다 이 함수가 실행된다.
+    // 로그인이 성공할 때 마다 이 함수가 실행된다.
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -66,7 +66,7 @@ public class LikeablePersonController {
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable("id") int id){
         LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
-        if (likeablePerson.getFromInstaMember().getId() != rq.getMember().getInstaMember().getId()) { //"호감을 표시한 멤버의 아이디"와 "현재 로그인한 회원의 인스타 아이디"가 같은지 확인하기
+        if (likeablePerson.getFromInstaMember().getId() != rq.getMember().getInstaMember().getId()) { //"호감을 표시한 멤버의 인스타 아이디"와 "현재 로그인한 회원의 인스타 아이디"가 같은지 확인하기
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
         }
         likeablePersonService.delete(likeablePerson);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -73,10 +73,9 @@ public class LikeablePersonController {
     public String delete(@PathVariable("id") Long id){
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        if (likeablePerson == null) return rq.historyBack("이미 취소된 호감입니다.");
+        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
 
-        if (!Objects.equals(rq.getMember().getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
-            return rq.historyBack("권한이 없습니다.");
+        if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
 
         RsData deleteRs = likeablePersonService.delete(likeablePerson);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -9,18 +9,13 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Objects;
+import java.util.NoSuchElementException;
 
 @Controller
 @RequestMapping("/likeablePerson")
@@ -69,7 +64,7 @@ public class LikeablePersonController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public String delete(@PathVariable("id") Long id){
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -9,11 +9,14 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -58,5 +61,15 @@ public class LikeablePersonController {
         }
 
         return "usr/likeablePerson/list";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String delete(@PathVariable("id") int id){
+        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
+        if (likeablePerson.getFromInstaMember().getId() != rq.getMember().getInstaMember().getId()) { //"호감을 표시한 멤버의 아이디"와 "현재 로그인한 회원의 인스타 아이디"가 같은지 확인하기
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
+        }
+        likeablePersonService.delete(likeablePerson);
+        return rq.redirectWithMsg("/likeablePerson/list", "삭제");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Integer> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -61,5 +62,14 @@ public class LikeablePersonService {
         likeablePersonRepository.delete(likeablePerson);
 
         return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
+    }
+
+    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
+        if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
+
+        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+            return RsData.of("F-2", "권한이 없습니다.");
+
+        return RsData.of("S-1", "삭제가능합니다.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+import com.ll.gramgram.DataNotFoundException;
 import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -47,5 +49,19 @@ public class LikeablePersonService {
 
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
+    }
+
+    public LikeablePerson getLikeablePerson(Integer id) {
+        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
+        if (likeablePerson.isPresent()) {
+            return likeablePerson.get();
+        } else {
+            throw new DataNotFoundException("likeablePerson not found");
+        }
+    }
+
+    @Transactional
+    public void delete(LikeablePerson likeablePerson) { //호감 받은 사람 삭제하기
+        likeablePersonRepository.delete(likeablePerson);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -51,17 +51,15 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
 
-    public LikeablePerson getLikeablePerson(Integer id) {
-        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
-        if (likeablePerson.isPresent()) {
-            return likeablePerson.get();
-        } else {
-            throw new DataNotFoundException("likeablePerson not found");
-        }
+    public Optional<LikeablePerson> findById(Long id) {
+        return likeablePersonRepository.findById(id);
     }
 
     @Transactional
-    public void delete(LikeablePerson likeablePerson) { //호감 받은 사람 삭제하기
+    public RsData delete(LikeablePerson likeablePerson) {
+        String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
         likeablePersonRepository.delete(likeablePerson);
+
+        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
     }
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -1,0 +1,10 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: 079ff55baf20b8290387cd7c4503deb8
+          google:
+            clientId: 203826557370-rd9jogul83srsgngo82v1ej42su1cn5j.apps.googleusercontent.com
+            client-secret: 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

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -1,0 +1,10 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: '카카오 REST API 키'
+          google:
+            clientId: '구글 클라이언트 ID'
+            client-secret: '구글 클라이언트 보안 비밀번호'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
   profiles:
     active: dev
     include: secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,13 +19,12 @@ spring:
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
             client-authentication-method: POST
           google:
-            scope:
-              - email
-              - profile
-            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope: profile
+            client-name: Google
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: dev
+    include: secret
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://127.0.0.1:3306/gram__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
@@ -11,15 +12,12 @@ spring:
       client:
         registration:
           kakao:
-            clientId: 1ea643a7d050980d9ec8bb877d00dba1
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             client-authentication-method: POST
           google:
-            clientId: 212571681532-o2gmeo2uqjm9kbm9f0ggsgoriahqljpd.apps.googleusercontent.com
-            client-secret: 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
             scope:
               - email
               - profile

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,13 @@ spring:
             authorization-grant-type: authorization_code
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             client-authentication-method: POST
+          google:
+            clientId: 212571681532-o2gmeo2uqjm9kbm9f0ggsgoriahqljpd.apps.googleusercontent.com
+            client-secret: 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
+            scope:
+              - email
+              - profile
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -21,7 +21,10 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
+                <a href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();">삭제</a>
+                <form hidden th:action="@{|/likeablePerson/${likeablePerson.id}|}" method="POST">
+                    <input type="hidden" name="_method" value="delete">
+                </form>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -63,7 +63,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/google">
-            구글 로그인하기(아직 안됨)
+            구글로 로그인하기
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,6 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
+import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -27,6 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class LikeablePersonControllerTests {
     @Autowired
     private MockMvc mvc;
+    @Autowired
+    private LikeablePersonService likeablePersonService;
 
     @Test
     @DisplayName("등록 폼(인스타 인증을 안해서 폼 대신 메세지)")
@@ -153,6 +157,7 @@ public class LikeablePersonControllerTests {
 
     @Test
     @DisplayName("호감 받은 사람 삭제")
+    @WithUserDetails("user3")
     void t006() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
@@ -167,6 +172,8 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("/likeablePerson/list"));
+                .andExpect(redirectedUrlPattern("/likeablePerson/list**"));
+
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -155,7 +156,9 @@ public class LikeablePersonControllerTests {
     void t006() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
-                .perform(get("/likeablePerson/delete/1")
+                .perform(
+                        delete("/likeablePerson/1")
+                                .with(csrf())
                 )
                 .andDo(print());
 

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -149,4 +149,21 @@ public class LikeablePersonControllerTests {
                         """.stripIndent().trim())));
         ;
     }
+
+    @Test
+    @DisplayName("호감 받은 사람 삭제")
+    void t006() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/likeablePerson/delete/1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/likeablePerson/list"));
+    }
 }


### PR DESCRIPTION
## Title: [1Week] 김희연

### 미션 요구사항 분석 & 체크리스트

---

**호감 상대 삭제**

[x] 호감 상대 삭제 테스트 코드 작성

[x] 삭제 시, 삭제 권한이 있는지 체크

[x] 삭제 후, 다시 호감 목록 페이지로 이동

<br>

**구글 로그인**

[x] 구글 로그인으로 가입한 회원인 providerTypeCode : GOOGLE

[x] 로그인 후, username 출력

<br>

### 1주차 미션 요약

---

**호감 상대 삭제**
- 삭제버튼을 누르면, 해당 항목은 삭제되어야 한다.
- 삭제 후 다시 호감 목록 페이지로 돌아와야 한다. (rq.redirectWithMsg 함수 사용)

**구글 로그인**
- 구글 로그인으로 가입 및 로그인 처리(스프링 OAuth2 클라이언트로 구현)
- 구글 로그인으로 가입한 회원의 providerTypeCode : GOOGLE

<br>

[접근 방법]
- 삭제 권한 체크

<첫번째 시도>

현재 로그인한 회원의 정보가 있어야한다는 생각에 `Principal`을 사용하였다.

`Principal.getName()`과 비교하기 위해서 `호감을 표시한 멤버의 username`이 필요했다.

[`호감을 표시한 멤버의 username` 구하기]

1. 호감을 받은 받은 사람 객체를 구하기
2. 호감 받은 사람에 대해 호감을 표시한 사람의 인스타 아이디 구하기
3. 인스타 아이디에 해당하는 멤버 객체 구하기

`호감 표시를 한 멤버의 아이디`와 `현재 로그인한 회원의 username`이 같은지 확인

```java
@PreAuthorize("isAuthenticated()")
@GetMapping("/delete/{id}")
public String delete(Principal principal, @PathVariable("id") int id){
    //호감을 받은 사람(LikeablePerson) - 호감을 표시한 사람(InstaMember) - 회원가입한 모든 회원(Member) 가 모두 연결되어 있다.
    LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
    Long InstaMemberId = likeablePerson.getFromInstaMember().getId(); //호감 받은 사람에 대해 호감 표시를 한 사람의 인스타 아이디 구하기
    Member member = memberService.getMember(InstaMemberId).get(); //인스타 아이디에 해당하는 멤버 객체 구하기
    if (!member.getUsername().equals(principal.getName())) { //호감 표시를 멤버의 아이디와 현재 로그인한 회원의 아이디와 같은지 확인하기
        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
    }
    likeablePersonService.delete(likeablePerson);
    return rq.redirectWithMsg("/likeablePerson/list", "삭제");
}
```
<br>

<두번째 시도>

이미 만들어놓은 `Rq`를 사용하면 조금 더 편리해질 것 같았다.

```java

@GetMapping("/delete/{id}")
public String delete(@PathVariable("id") int id){
    //호감을 받은 사람(LikeablePerson) - 호감을 표시한 사람(InstaMember) - 회원가입한 모든 회원(Member) 가 모두 연결되어 있다.
    LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
    Long InstaMemberId = likeablePerson.getFromInstaMember().getId(); //호감 받은 사람에 대해 호감 표시를 한 사람의 인스타 아이디 구하기
    Member member = memberService.getMember(InstaMemberId).get(); //인스타 아이디에 해당하는 멤버 객체 구하기
    if (!member.getUsername().equals(rq.getMember().getUsername())) { //호감 표시를 멤버의 아이디와 현재 로그인한 회원의 아이디와 같은지 확인하기
        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
    }
    likeablePersonService.delete(likeablePerson);
    return rq.redirectWithMsg("/likeablePerson/list", "삭제");
}
```
<br>

<세번째 시도_최종코드>

강사님의 힌트로, 삭제 권한을 확인하는 조건은 `멤버의 username`이 아닌 `인스타 아이디`라는 것을 알게되었다.

- 호감을 표시한 사람이 삭제 권한이 있으므로 호감을 표시한 사람인지를 확인해야 한다.
- 호감을 표시한 사람은 인스타 아이디로 확인가능하다.

`호감을 표시한 멤버의 인스타 아이디` 와 `현재 로그인한 회원의 인스타 아이디` 가 같은지 확인

```java
@GetMapping("/delete/{id}")
    public String delete(@PathVariable("id") int id){
        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id); //호감을 받은 사람 객체 구하기
        if (likeablePerson.getFromInstaMember().getId() != rq.getMember().getInstaMember().getId()) { //"호감을 표시한 멤버의 인스타 아이디"와 "현재 로그인한 회원의 인스타 아이디"가 같은지 확인하기
            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제권한이 없습니다.");
        }
        likeablePersonService.delete(likeablePerson);
        return rq.redirectWithMsg("/likeablePerson/list", "삭제");
    }
```

첫번째 코드가 틀렸다고는 할 수 없지만, 삭제 조건에 대해 많이 돌아가서 구현했다면, 세번째 코드는 훨씬 간결해진 것을 볼 수 있다!

<br>

- 구글 계정 접속

이전에 구현한 카카오 로그인과 관련된 소스 코드를 참고하였다.

`CustomOAuth2UserService`, `SecurityConfig`, `MemberService-join()`, `MemberService-whenSocialLogin` 등이 관련되어 있었지만, 구글 로그인 또한 함께 써도 무방하였다.

그래서 수정한 코드는 `application.yml` 코드 뿐이다.
Google에 맞춰서 수정하기 위해서 구글 검색을 많이 하였고, 여러 블로그들을 참고하였다.

또한, `client-id`와 `client-secret`을 구하기 위해 계정을 생성하였다.

<br>

**[특이사항]**
- 삭제 버튼을 눌렀으나, 삭제가 되지 않았다.
-> `@Transactional(readOnly = true)` 때문이었다. `@Transactional`을 붙여주어야 한다.


- 구글 소셜 로그인과 관련한 블로그들은 많았지만, 이들을 조합해서 나에게 맞는 소스 코드로 적용하기까지 시간이 많이 소요되었다.