### PR TITLE
4 week

### DIFF
--- a/records/4Week_KimHeeYeon.md
+++ b/records/4Week_KimHeeYeon.md
@@ -1,0 +1,142 @@
+## Title: [4Week] 김희연
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+
+### 필수 미션
+
+****네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용****
+
+- `https://도메인/` 형태로 접속이 가능
+- 운영서버에서 각종 소셜로그인, 인스타 아이디 연결이 잘 되어야 함
+
+****내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현****
+
+- 내가 받은 호감리스트에서 특정 성별을 가진 사람에게서 받은 호감만 필터링
+
+[x] 남성을 조회하면 남성이 호감표시한 리스트들만 출력
+
+[x] 여성을 조회하면 여성이 호감표시한 리스트들만 출력
+
+### 선택 미션
+
+**젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포 진행**
+
+- 수행하지 못함
+
+**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현**
+
+- 내가 받은 호감리스트에서 특정 호감사유의 호감만 필터링
+
+[x] 내가 받은 호감리스트에서 호감사유에 해당하는 리스트들만 출력
+
+****내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능****
+
+- 최신순(기본)
+    - 최근에 받은 호감표시를 우선적으로 표시
+- 날짜순
+    - 오래전에 받은 호감표시를 우선적으로 표시
+- 인기 많은 순
+    - 인기가 많은 사람의 호감표시를 우선적으로 표시
+- 인기 적은 순
+    - 인기가 적은 사람의 호감표시를 우선적으로 표시
+- 성별순
+    - 여성에게 받은 호감표시를 먼저 표시하고, 그 다음 남자에게 받은 호감표시를 후에 표시
+    - 2순위 정렬조건으로는 최신순
+- 호감사유순
+    - 외모 때문에 받은 호감표시를 먼저 표시하고, 그 다음 성격 때문에 받은 호감표시를 후에 표시, 마지막으로 능력 때문에 받은 호감표시를 후에 표시
+    - 2순위 정렬조건으로는 최신순
+
+### 4주차 미션 요약
+
+---
+
+### [접근 방법]
+
+### 필수 미션
+
+****네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용****
+
+- 강사님 가이드 영상 보면서 진행
+
+****내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현****
+
+- `LikeablePersonController` 에서 `@RequestParam` 을 통해 `gender` 값을 받아옴
+- `if (gender != null && gender.length() > 0)`
+    - 처음 `/usr/likeablePerson/toList` 로 접속했을 때 `gender` 자체가 없을 경우에 `null` 이 올 수 도 있고, `gender=` 일 경우에는  `""` 빈문자열이 올 수 도 있다.
+    - 두 경우를 모두 판단하여 조건문을 구현하였다.
+- 조건은 맞은 거 같은데 출력이 되지 않아 어려움을 겪었었다.
+    - Stream 형식으로 변환한 값을 바로 출력하도록 했는데, List로 형식으로 바꿔서 출력을 했어야 했다.
+
+  [처음 코드]
+
+    ```java
+    if(gender != null && gender.length() > 0){
+                    stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
+    					   }
+    
+    model.addAttribute("likeablePeople", stream);
+    ```
+
+  [개선 코드]
+
+    ```java
+    if(gender != null && gender.length() > 0){
+                    stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
+                }
+    
+    List<LikeablePerson> newData = stream.collect(Collectors.toList()); //List로 변환
+    
+    model.addAttribute("likeablePeople", newData);
+    ```
+
+
+### 선택 미션
+
+**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현**
+
+- `@RequestParam(defaultValue = "0") int attractiveTypeCode`
+    - `/usr/likeablePerson/toList` 로 접속했을 때 `attractiveattractiveTypeCode` 자체가 없을 경우에 `“0”` 으로 되고 int형으로 형변환되어  `0` 이 된다.
+    - `attractiveTypeCode=` 일 경우와 같이 값이 없을 경우에는 빈문자열 `""`이 들어가는데, int 형으로 형변환되어 초기값 `0` 이 된다.
+    - 따라서 `0`에 대한 처리만 해주면 된다.
+- `if (attractiveTypeCode != 0)`
+    - 호감사유의 값이 지정됐을 경우에만 해당 호감사유에 맞게 출력
+
+****내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능****
+
+- switch 문 사용
+- 최신순(기본)
+    - case 1
+    - `Comparator.*comparing*(LikeablePerson::getModifyDate, Comparator.*reverseOrder*())`
+    - 수정된 날짜를 기준으로 내림차순으로 정렬
+- 날짜순
+    - case 2
+    - `Comparator.*comparing*(LikeablePerson::getModifyDate)`
+    - 수정된 날짜를 기준으로 오름차순으로 정렬
+- 인기 많은 순
+    - case 3
+    - `Comparator.*comparingInt*(e -> -e.getFromInstaMember().getToLikeablePeople().size())`
+    - `호감 표시를 한 사람` 의 좋아요들의 개수를 비교하여 내림차순으로 정렬
+    - 내림차순으로 정렬하기 위해 `-` 를 붙였다.
+- 인기 적은 순
+    - case 4
+    - `Comparator.*comparingInt*(e -> e.getFromInstaMember().getToLikeablePeople().size())`
+    - `호감 표시를 한 사람` 의 좋아요들의 개수를 비교하여 오름차순으로 정렬
+- 성별순
+    - case 5
+    - `(LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)`
+    - 호감 표시한 사람의 성별이 여성이라면 0, 아니라면 1을 두어 여성이 앞에 오게끔 하였다.
+    - `.thenComparing(LikeablePerson::getModifyDate, Comparator.*reverseOrder*()`
+    - 성별이 같을 경우 최신순으로 정렬하기 위해 `.thenComparing` 을 사용하였다.
+- 호감사유순
+    - case 6
+    - `Comparator.*comparing*((LikeablePerson e) -> e.getAttractiveTypeCode())        .thenComparing(LikeablePerson::getModifyDate, Comparator.*reverseOrder*()));`
+    - `외모, 성격, 능력`의 `attractiveTypeCode`가 `1, 2, 3` 이므로 오름차순으로 정렬
+
+### **[특이 사항]**
+
+- 정렬하는 부분에서 case 3, case 4 는 `e -> -e.getFromInstaMember()` 와 같은 형식으로 `FromInstaMember` 를 불러올 수 있었는데,
+  case 5, case 6 은 `e -> -e.getFromInstaMember()` 와 같은 형식으로 구현하면 **`getFromInstaMember()에 대해서 Cannot resolve method 'getFromInstaMember' in 'Object'`**라는 오류가 떴다. → 메소드를 찾을 수 없다.
+
+  그래서 **명시적으로 LikeablePerson 유형을 지정**해야만 했는데, 그 이유가 궁금하다.

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -64,6 +64,10 @@ public class NotProd {
                 Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
                 LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+
+                likeablePersonService.like(memberUser2, "insta_user4", 2).getData();
+                likeablePersonService.like(memberUser5, "insta_user4", 3).getData();
+                likeablePersonService.like(memberUser2, "insta_user5", 1).getData();
             }
         };
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -124,7 +124,7 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model, String gender,
+    public String showToList(Model model, @RequestParam(defaultValue = "") String gender,
                              @RequestParam(defaultValue = "0") int attractiveTypeCode,
                              @RequestParam(defaultValue = "1") int sortCode) {
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -133,7 +133,7 @@ public class LikeablePersonController {
             // stream 형태로 변환
             Stream<LikeablePerson> stream = likeablePeople.stream();
 
-            if(gender != null){
+            if(gender != null && gender.length() > 0){
                 //해당 인스타회원을 좋아하는 사람들 중에서 성별이 gender과 같은 사람만 필터링
                 stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
             }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -125,10 +125,12 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
     public String showToList(Model model, String gender,
-                             @RequestParam(defaultValue = "0") int attractiveTypeCode) {
+                             @RequestParam(defaultValue = "0") int attractiveTypeCode,
+                             @RequestParam(defaultValue = "1") int sortCode) {
+
         InstaMember instaMember = rq.getMember().getInstaMember();
 
-        RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.getLikeablePeople(instaMember, gender, attractiveTypeCode);
+        RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.getLikeablePeople(instaMember, gender, attractiveTypeCode, sortCode);
         model.addAttribute("likeablePeople", likeablePeople.getData());
 
         return "usr/likeablePerson/toList";

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -126,10 +126,9 @@ public class LikeablePersonController {
     @GetMapping("/toList")
     public String showToList(Model model, String gender) {
         InstaMember instaMember = rq.getMember().getInstaMember();
-
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
-            // 해당 인스타회원이 좋아하는 사람들 목록
+            // 해당 인스타회원을 좋아하는 사람들 목록
             List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
             // stream 형태로 변환
             Stream<LikeablePerson> stream = likeablePeople.stream();

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -124,24 +124,12 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model, String gender) {
+    public String showToList(Model model, String gender,
+                             @RequestParam(defaultValue = "0") int attractiveTypeCode) {
         InstaMember instaMember = rq.getMember().getInstaMember();
-        // 인스타인증을 했는지 체크
-        if (instaMember != null) {
-            // 해당 인스타회원을 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
-            // stream 형태로 변환
-            Stream<LikeablePerson> stream = likeablePeople.stream();
 
-            if(gender != null && gender.length() > 0){
-                //해당 인스타회원을 좋아하는 사람들 중에서 성별이 gender과 같은 사람만 필터링
-                stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
-            }
-
-            List<LikeablePerson> newData = stream.collect(Collectors.toList());
-
-            model.addAttribute("likeablePeople", newData);
-        }
+        RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.getLikeablePeople(instaMember, gender, attractiveTypeCode);
+        model.addAttribute("likeablePeople", likeablePeople.getData());
 
         return "usr/likeablePerson/toList";
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -16,6 +16,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Controller
 @RequestMapping("/usr/likeablePerson")

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -16,6 +16,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Controller
@@ -123,14 +124,24 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model) {
+    public String showToList(Model model, String gender) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
             List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
-            model.addAttribute("likeablePeople", likeablePeople);
+            // stream 형태로 변환
+            Stream<LikeablePerson> stream = likeablePeople.stream();
+
+            if(gender != null){
+                //해당 인스타회원을 좋아하는 사람들 중에서 성별이 gender과 같은 사람만 필터링
+                stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
+            }
+
+            List<LikeablePerson> newData = stream.collect(Collectors.toList());
+
+            model.addAttribute("likeablePeople", newData);
         }
 
         return "usr/likeablePerson/toList";

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -15,6 +15,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -222,7 +223,7 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
     }
 
-    public RsData<List<LikeablePerson>> getLikeablePeople(InstaMember instaMember, String gender, int attractiveTypeCode) {
+    public RsData<List<LikeablePerson>> getLikeablePeople(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
@@ -236,6 +237,22 @@ public class LikeablePersonService {
 
             if (attractiveTypeCode != 0) {
                 stream = stream.filter(e -> e.getAttractiveTypeCode() == attractiveTypeCode);
+            }
+
+            switch (sortCode) {
+                case 1:
+                    stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
+                    break;
+                case 2:
+                    break;
+                case 3:
+                    break;
+                case 4:
+                    break;
+                case 5:
+                    break;
+                case 6:
+                    break;
             }
 
             List<LikeablePerson> newData = stream.collect(Collectors.toList());

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -247,8 +247,10 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate));
                     break;
                 case 3:
+                    stream = stream.sorted(Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size()));
                     break;
                 case 4:
+                    stream = stream.sorted(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
                     break;
                 case 5:
                     break;

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -244,10 +244,12 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparing(LikeablePerson::getId));
                     break;
                 case 3:
-                    stream = stream.sorted(Comparator.comparing(e -> -e.getFromInstaMember().getLikes()));
+                    stream = stream.sorted(Comparator.comparing((LikeablePerson e) -> -e.getFromInstaMember().getLikes())
+                            .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
                 case 4:
-                    stream = stream.sorted(Comparator.comparing(e -> e.getFromInstaMember().getLikes()));
+                    stream = stream.sorted(Comparator.comparing((LikeablePerson e) -> e.getFromInstaMember().getLikes())
+                            .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
                 case 5:
                     stream = stream.sorted(
@@ -256,7 +258,7 @@ public class LikeablePersonService {
                     break;
                 case 6:
                     stream = stream.sorted(
-                            Comparator.comparing((LikeablePerson e) -> e.getAttractiveTypeCode())
+                            Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
                                     .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
             }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -244,7 +244,7 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparing(LikeablePerson::getId));
                     break;
                 case 3:
-                    stream = stream.sorted(Comparator.comparing(e -> e.getFromInstaMember().getLikes(), Comparator.reverseOrder()));
+                    stream = stream.sorted(Comparator.comparing(e -> -e.getFromInstaMember().getLikes()));
                     break;
                 case 4:
                     stream = stream.sorted(Comparator.comparing(e -> e.getFromInstaMember().getLikes()));

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -218,5 +220,28 @@ public class LikeablePersonService {
 
 
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
+    }
+
+    public RsData<List<LikeablePerson>> getLikeablePeople(InstaMember instaMember, String gender, int attractiveTypeCode) {
+        // 인스타인증을 했는지 체크
+        if (instaMember != null) {
+            // 해당 인스타회원이 좋아하는 사람들 목록
+            List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
+
+            Stream<LikeablePerson> stream = likeablePeople.stream();
+
+            if (gender != null && gender.length() > 0) {
+                stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
+            }
+
+            if (attractiveTypeCode != 0) {
+                stream = stream.filter(e -> e.getAttractiveTypeCode() == attractiveTypeCode);
+            }
+
+            List<LikeablePerson> newData = stream.collect(Collectors.toList());
+
+            return RsData.of("S-1", "내가 받은 호감리스트에서 필터링되어 출력됩니다.", newData);
+        }
+        return RsData.of("F-1", "먼저 본인의 인스타그램 아이디를 입력해주세요.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -231,7 +231,7 @@ public class LikeablePersonService {
 
             Stream<LikeablePerson> stream = likeablePeople.stream();
 
-            if (gender != null && gender.length() > 0) {
+            if (!gender.isEmpty()) {
                 stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
             }
 
@@ -240,11 +240,8 @@ public class LikeablePersonService {
             }
 
             switch (sortCode) {
-                case 1:
-                    stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
-                    break;
                 case 2:
-                    stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate));
+                    stream = stream.sorted(Comparator.comparing(LikeablePerson::getId));
                     break;
                 case 3:
                     stream = stream.sorted(Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size()));

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -244,10 +244,10 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparing(LikeablePerson::getId));
                     break;
                 case 3:
-                    stream = stream.sorted(Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size()));
+                    stream = stream.sorted(Comparator.comparing(e -> e.getFromInstaMember().getLikes(), Comparator.reverseOrder()));
                     break;
                 case 4:
-                    stream = stream.sorted(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
+                    stream = stream.sorted(Comparator.comparing(e -> e.getFromInstaMember().getLikes()));
                     break;
                 case 5:
                     stream = stream.sorted(

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -244,6 +244,7 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
                 case 2:
+                    stream = stream.sorted(Comparator.comparing(LikeablePerson::getModifyDate));
                     break;
                 case 3:
                     break;

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -258,6 +258,9 @@ public class LikeablePersonService {
                                     .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
                 case 6:
+                    stream = stream.sorted(
+                            Comparator.comparing((LikeablePerson e) -> e.getAttractiveTypeCode())
+                                    .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
             }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -253,6 +253,9 @@ public class LikeablePersonService {
                     stream = stream.sorted(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
                     break;
                 case 5:
+                    stream = stream.sorted(
+                            Comparator.comparing((LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)
+                                    .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
                     break;
                 case 6:
                     break;

--- a/src/main/resources/templates/usr/likeablePerson/toList.html
+++ b/src/main/resources/templates/usr/likeablePerson/toList.html
@@ -74,7 +74,7 @@
                             <select name="sortCode" class="select select-bordered w-full"
                                     onchange="$(this).closest('form').submit();">
                                 <option value="1">최신순</option>
-                                <option value="2">날짜순</option>
+                                <option value="2">오래된순</option>
                                 <option value="3">인기 많은 순</option>
                                 <option value="4">인기 적은 순</option>
                                 <option value="5">성별순</option>

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -472,4 +472,23 @@ public class LikeablePersonControllerTests {
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(model().attribute("likeablePeople", hasSize(1))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
     }
+
+    @Test
+    @DisplayName("내가 받은 호감리스트에서 호감사유에 해당하는 리스트들만 출력된다.")
+    @WithUserDetails("user4")
+    void t020() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(model().attribute("likeablePeople", hasSize(1))); //user4에는 호감사유가 외모인 호감표시가 1개 있으므로 리스트의 사이즈는 1이다.
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -470,7 +470,7 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("showToList"))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(model().attribute("likeablePeople", hasSize(1))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
+                .andExpect(model().attribute("likeablePeople", hasSize(2))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
     }
 
     @Test

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -451,7 +451,7 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("showToList"))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(model().attribute("likeablePeople", hasSize(0))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 0이다.
+                .andExpect(model().attribute("likeablePeople", hasSize(1))); //user4에는 남성 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
     }
 
     @Test
@@ -470,7 +470,7 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("showToList"))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(model().attribute("likeablePeople", hasSize(2))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
+                .andExpect(model().attribute("likeablePeople", hasSize(2))); //user4에는 여성이 두 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
     }
 
     @Test

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -432,5 +433,43 @@ public class LikeablePersonControllerTests {
                 .andExpect(status().is4xxClientError());
 
         assertThat(likeablePersonService.findById(3L).get().getAttractiveTypeCode()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("필터링으로 남성을 조회하면 남성이 호감표시한 리스트들만 출력된다.")
+    @WithUserDetails("user4")
+    void t018() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList")
+                        .param("gender", "M")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(model().attribute("likeablePeople", hasSize(0))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 0이다.
+    }
+
+    @Test
+    @DisplayName("필터링으로 여성을 조회하면 여성이 호감표시한 리스트들만 출력된다.")
+    @WithUserDetails("user4")
+    void t019() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/usr/likeablePerson/toList")
+                        .param("gender", "W")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(model().attribute("likeablePeople", hasSize(1))); //user4에는 여성이 한 명이 호감표시를 하고 있으므로 리스트의 사이즈는 1이다.
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -276,9 +276,9 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 1);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(5L));
-        assertThat(newData.get(0).getId().equals(4L));
-        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId()).isEqualTo(5L);
+        assertThat(newData.get(1).getId()).isEqualTo(4L);
+        assertThat(newData.get(2).getId()).isEqualTo(1L);
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
     }
@@ -293,15 +293,15 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 2);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(1L));
-        assertThat(newData.get(0).getId().equals(4L));
-        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId()).isEqualTo(1L);
+        assertThat(newData.get(1).getId()).isEqualTo(4L);
+        assertThat(newData.get(2).getId()).isEqualTo(5L);
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
     }
 
     @Test
-    @DisplayName("인기 많은 순 - 오래전에 받은 호감표시를 우선적으로 표시")
+    @DisplayName("인기 많은 순 - 인기가 많은 호감표시를 우선적으로 표시")
     @Rollback(false)
     void t011() {
         Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
@@ -310,11 +310,11 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 3);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(5L));
-        assertThat(newData.get(0).getId().equals(1L));
-        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId()).isEqualTo(5L);
+        assertThat(newData.get(1).getId()).isEqualTo(4L);
+        assertThat(newData.get(2).getId()).isEqualTo(1L);
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparing(e -> e.getFromInstaMember().getLikes(), Comparator.reverseOrder()));
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(e -> -e.getFromInstaMember().getLikes()));
     }
 
     @Test
@@ -327,9 +327,9 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 4);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(4L));
-        assertThat(newData.get(0).getId().equals(1L));
-        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId()).isEqualTo(4L);
+        assertThat(newData.get(1).getId()).isEqualTo(1L);
+        assertThat(newData.get(2).getId()).isEqualTo(5L);
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing(e -> e.getFromInstaMember().getLikes()));
     }
@@ -344,9 +344,9 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 5);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(1L));
-        assertThat(newData.get(0).getId().equals(5L));
-        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId()).isEqualTo(5L);
+        assertThat(newData.get(1).getId()).isEqualTo(1L);
+        assertThat(newData.get(2).getId()).isEqualTo(4L);
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing((LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)
                 .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
@@ -362,11 +362,11 @@ public class LikeablePersonServiceTests {
         RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 6);
         List<LikeablePerson> newData = result.getData();
 
-        assertThat(newData.get(0).getId().equals(1L));
-        assertThat(newData.get(0).getId().equals(4L));
-        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId()).isEqualTo(1L);
+        assertThat(newData.get(1).getId()).isEqualTo(4L);
+        assertThat(newData.get(2).getId()).isEqualTo(5L);
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparing((LikeablePerson e) -> e.getAttractiveTypeCode())
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getAttractiveTypeCode)
                 .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -280,7 +280,7 @@ public class LikeablePersonServiceTests {
         assertThat(newData.get(0).getId().equals(4L));
         assertThat(newData.get(0).getId().equals(1L));
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId, Comparator.reverseOrder()));
     }
 
     @Test
@@ -297,7 +297,7 @@ public class LikeablePersonServiceTests {
         assertThat(newData.get(0).getId().equals(4L));
         assertThat(newData.get(0).getId().equals(5L));
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate));
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getId));
     }
 
     @Test
@@ -314,7 +314,7 @@ public class LikeablePersonServiceTests {
         assertThat(newData.get(0).getId().equals(1L));
         assertThat(newData.get(0).getId().equals(4L));
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size()));
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(e -> e.getFromInstaMember().getLikes(), Comparator.reverseOrder()));
     }
 
     @Test
@@ -331,7 +331,7 @@ public class LikeablePersonServiceTests {
         assertThat(newData.get(0).getId().equals(1L));
         assertThat(newData.get(0).getId().equals(5L));
 
-        assertThat(newData).isSortedAccordingTo(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(e -> e.getFromInstaMember().getLikes()));
     }
 
     @Test

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -351,4 +351,22 @@ public class LikeablePersonServiceTests {
         assertThat(newData).isSortedAccordingTo(Comparator.comparing((LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)
                 .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
     }
+
+    @Test
+    @DisplayName("호감사유순 - 외모, 성격, 능력순으로 표시, 2순위 정렬조건으로는 최신순")
+    @Rollback(false)
+    void t014() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //호감사유순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 6);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId().equals(5L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing((LikeablePerson e) -> e.getAttractiveTypeCode())
+                .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -280,5 +281,22 @@ public class LikeablePersonServiceTests {
         assertThat(newData.get(0).getId().equals(1L));
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
+    }
+
+    @Test
+    @DisplayName("날짜순 - 오래전에 받은 호감표시를 우선적으로 표시")
+    @Rollback(false)
+    void t010() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //날짜순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 2);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId().equals(5L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate));
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -299,4 +299,38 @@ public class LikeablePersonServiceTests {
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate));
     }
+
+    @Test
+    @DisplayName("인기 많은 순 - 오래전에 받은 호감표시를 우선적으로 표시")
+    @Rollback(false)
+    void t011() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //인기 많은 순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 3);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId().equals(4L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size()));
+    }
+
+    @Test
+    @DisplayName("인기 적은 순 - 인기가 적은 사람의 호감표시를 우선적으로 표시")
+    @Rollback(false)
+    void t012() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //인기 적은 순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 4);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId().equals(5L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -3,6 +3,7 @@ package com.ll.gramgram.boundedContext.likeablePerson.service;
 
 import com.ll.gramgram.TestUt;
 import com.ll.gramgram.base.appConfig.AppConfig;
+import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
@@ -18,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -262,5 +264,21 @@ public class LikeablePersonServiceTests {
         assertThat(
                 likeablePersonToBts.getModifyUnlockDate().isAfter(coolTime)
         ).isTrue();
+    }
+
+    @Test
+    @DisplayName("최신순 - 최근에 받은 호감표시를 우선적으로 표시")
+    void t009() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //최신순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 1);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId().equals(4L));
+        assertThat(newData.get(0).getId().equals(1L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -333,4 +333,22 @@ public class LikeablePersonServiceTests {
 
         assertThat(newData).isSortedAccordingTo(Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size()));
     }
+
+    @Test
+    @DisplayName("성별순 - 여성에게 받은 호감표시를 우선으로 표시, 2순위 정렬조건은 최신순")
+    @Rollback(false)
+    void t013() {
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+
+        //성별순으로 정렬
+        RsData<List<LikeablePerson>> result = likeablePersonService.getLikeablePeople(memberUser4.getInstaMember(), "", 0, 5);
+        List<LikeablePerson> newData = result.getData();
+
+        assertThat(newData.get(0).getId().equals(1L));
+        assertThat(newData.get(0).getId().equals(5L));
+        assertThat(newData.get(0).getId().equals(4L));
+
+        assertThat(newData).isSortedAccordingTo(Comparator.comparing((LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)
+                .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));
+    }
 }


### PR DESCRIPTION
## Title: [4Week] 김희연

### 미션 요구사항 분석 & 체크리스트

---

### 필수 미션

**네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용**

- `https://도메인/` 형태로 접속이 가능
- 운영서버에서 각종 소셜로그인, 인스타 아이디 연결이 잘 되어야 함

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현**

- 내가 받은 호감리스트에서 특정 성별을 가진 사람에게서 받은 호감만 필터링
- [x]  남성을 조회하면 남성이 호감표시한 리스트들만 출력
- [x]  여성을 조회하면 여성이 호감표시한 리스트들만 출력

### 선택 미션

**젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포 진행**

- 수행하지 못함

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현**

- 내가 받은 호감리스트에서 특정 호감사유의 호감만 필터링
- [x]  내가 받은 호감리스트에서 호감사유에 해당하는 리스트들만 출력

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능**

- 최신순(기본)
    - 최근에 받은 호감표시를 우선적으로 표시
- 날짜순
    - 오래전에 받은 호감표시를 우선적으로 표시
- 인기 많은 순
    - 인기가 많은 사람의 호감표시를 우선적으로 표시
    - 2순위 정렬조건으로는 최신순
- 인기 적은 순
    - 인기가 적은 사람의 호감표시를 우선적으로 표시
    - 2순위 정렬조건으로는 최신순
- 성별순
    - 여성에게 받은 호감표시를 먼저 표시하고, 그 다음 남자에게 받은 호감표시를 후에 표시
    - 2순위 정렬조건으로는 최신순
- 호감사유순
    - 외모 때문에 받은 호감표시를 먼저 표시하고, 그 다음 성격 때문에 받은 호감표시를 후에 표시, 마지막으로 능력 때문에 받은 호감표시를 후에 표시
    - 2순위 정렬조건으로는 최신순

### 4주차 미션 요약

---

### [접근 방법]

### 필수 미션

**네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용**

- 강사님 가이드 영상 보면서 진행

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현**

- `@RequestParam String gender`
    - `LikeablePersonController` 에서 `@RequestParam` 을 통해 `gender` 값을 받아옴
- `if (gender != null && gender.length() > 0)`
    - 처음 `/usr/likeablePerson/toList` 로 접속했을 때 `gender` 자체가 없을 경우에 `null` 이 올 수 도 있고, `gender=` 일 경우에는 `""` 빈문자열이 올 수 도 있다.
    - 두 경우를 모두 판단하여 조건문을 구현하였다.

[리팩토링]

- `@RequestParam(defaultValue = "") String gender`
    - gender에 `(defaultValue = "")`을 지정하여 null값이 아닌 `""`빈문자열이 오도록 하여 빈문자열에 대해서만 처리할 수 있도록 변경
- `if (!gender.isEmpty())`
    - 빈문자열이 아닐 경우에 처리하도록 구현
- 조건은 맞은 거 같은데 출력이 되지 않아 어려움을 겪었었다.
    - Stream 형식으로 변환한 값을 바로 출력하도록 했는데, List로 형식으로 바꿔서 출력을 했어야 했다.
    
    [처음 코드]
    
    ```
    if(!gender.isEmpty()){
                    stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
    					   }
    
    model.addAttribute("likeablePeople", stream);
    
    ```
    
    [개선 코드]
    
    ```
    if(!gender.isEmpty()){
                    stream = stream.filter(e -> e.getFromInstaMember().getGender().equals(gender));
                }
    
    List<LikeablePerson> newData = stream.collect(Collectors.toList()); //List로 변환
    
    model.addAttribute("likeablePeople", newData);
    
    ```
    

### 선택 미션

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현**

- `@RequestParam(defaultValue = "0") int attractiveTypeCode`
    - `/usr/likeablePerson/toList` 로 접속했을 때 `attractiveattractiveTypeCode` 자체가 없을 경우에 `“0”` 으로 되고 int형으로 형변환되어 `0` 이 된다.
    - `attractiveTypeCode=` 일 경우와 같이 값이 없을 경우에는 빈문자열 `""`이 들어가는데, int 형으로 형변환되어 초기값 `0` 이 된다.
    - 따라서 `0`에 대한 처리만 해주면 된다.
- `if (attractiveTypeCode != 0)`
    - 호감사유의 값이 지정됐을 경우에만 해당 호감사유에 맞게 출력

**내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능**

- switch 문 사용
- 최신순(기본)
    - case 1
    - `Comparator.comparing(LikeablePerson::getModifyDate, Comparator.reverseOrder())`
    - 수정된 날짜를 기준으로 내림차순으로 정렬

[리팩토링]
최신순을 `수정날짜` 기준이 아닌 `생성날짜`로 변경 -> `생성날짜`는 `id`의 순서와 같음 -> `id`는 이미 최신순으로 정렬되어 있음 -> 생략

- 날짜순
    - case 2
    - `Comparator.comparing(LikeablePerson::getId)`
    - 수정된 날짜를 기준으로 오름차순으로 정렬
- 인기 많은 순
    - case 3
    - `Comparator.comparingInt(e -> -e.getFromInstaMember().getToLikeablePeople().size())`
    `.thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));`
    - `호감 표시를 한 사람` 의 좋아요들의 개수를 비교하여 내림차순으로 정렬
    - 내림차순으로 정렬하기 위해 `-` 를 붙였다.
    - 인기수가 같을 경우 최신순으로 정렬하기 위해 `.thenComparing` 을 사용
- 인기 적은 순
    - case 4
    - `Comparator.comparingInt(e -> e.getFromInstaMember().getToLikeablePeople().size())`
    `.thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));`
    - `호감 표시를 한 사람` 의 좋아요들의 개수를 비교하여 오름차순으로 정렬
    - 이기수가 같을 경우 최신순으로 정렬

[리팩토링]

`.getToLikeablePeople().size()` 를 `.getLikes()` 로 변경

- 성별순
    - case 5
    - `(LikeablePerson e) -> e.getFromInstaMember().getGender().equals("W") ? 0 : 1)`
    - 호감 표시한 사람의 성별이 여성이라면 0, 아니라면 1을 두어 여성이 앞에 오게끔 하였다.
    - `.thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()`
    - 성별이 같을 경우 최신순으로 정렬
- 호감사유순
    - case 6
    - `Comparator.comparing((LikeablePerson e) -> e.getAttractiveTypeCode()) .thenComparing(LikeablePerson::getModifyDate, Comparator.reverseOrder()));`
    - `외모, 성격, 능력`의 `attractiveTypeCode`가 `1, 2, 3` 이므로 오름차순으로 정렬
    - 호감사유가 같을 경우 최신순으로 정렬

### **[특이 사항]**

- 정렬하는 부분에서 case 3, case 4 는 `e -> -e.getFromInstaMember()` 와 같은 형식으로 `FromInstaMember` 를 불러올 수 있었는데,
case 5, case 6 은 `e -> -e.getFromInstaMember()` 와 같은 형식으로 구현하면 `getFromInstaMember()에 대해서 Cannot resolve method 'getFromInstaMember' in 'Object'`라는 오류가 떴다. → 메소드를 찾을 수 없다.
    
    그래서 **명시적으로 LikeablePerson 유형을 지정**해야만 했는데, 그 이유가 궁금하다.
    
    ⇒ 제네릭이 지원을 해주지 않기 때문